### PR TITLE
Remove third party action coverage reporter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,11 +24,6 @@ jobs:
         run: yarn lint
       - name: Run unit tests
         run: yarn test:ci
-      - name: Archive code coverage report
-        uses: actions/upload-artifact@v3
-        with:
-          name: code-coverage-report
-          path: coverage/report.json
       - name: Push tag for new package version
         uses: anothrNick/github-tag-action@1.61.0
         env:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,21 +22,6 @@ jobs:
         run: yarn lint
       - name: Run unit tests
         run: yarn test:ci
-      - name: Download artifact
-        id: download-artifact
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow: main.yml
-          branch: main
-          name: code-coverage-report
-          path: coverage/base
-      - name: Report test coverage
-        uses: ArtiomTr/jest-coverage-report-action@v2
-        with:
-          annotations: none
-          base-coverage-file: coverage/base/report.json
-          coverage-file: coverage/report.json
-          skip-step: all
 
   # Used as the required status check on PRs so a failure prevents a merge
   build-result:


### PR DESCRIPTION
Dependabot PRs were failing due to lack of permissions.